### PR TITLE
Ignore new schemas directory

### DIFF
--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -48,4 +48,4 @@ config =
     , NoUnused.Modules.rule
     , NoRedundantConcat.rule
     ]
-        |> List.map (ignoreErrorsForDirectories [ "src/Api/Paack/Graphql" ])
+        |> List.map (ignoreErrorsForDirectories [ "src/Api/Paack/Graphql", "src/Schemas" ])


### PR DESCRIPTION
On LMO, starting with https://github.com/PaackEng/lmo-web/pull/17, will be adopting a new "src/Schemas/LMO" directory for Graphql schemas modules.