### PR TITLE
Ignore generated I18n

### DIFF
--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -48,4 +48,4 @@ config =
     , NoUnused.Modules.rule
     , NoRedundantConcat.rule
     ]
-        |> List.map (ignoreErrorsForDirectories [ "src/Api/Paack/Graphql", "src/Schemas" ])
+        |> List.map (ignoreErrorsForDirectories [ "src/Api/Paack/Graphql", "src/Schemas", "src/I18n" ])


### PR DESCRIPTION
We have this on paack-ui. They're generated and have types that not necessarily are being used.