### PR TITLE
Ignore parent's "src"

### DIFF
--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -48,4 +48,4 @@ config =
     , NoUnused.Modules.rule
     , NoRedundantConcat.rule
     ]
-        |> List.map (ignoreErrorsForDirectories [ "src/Api/Paack/Graphql", "src/Schemas", "src/I18n" ])
+        |> List.map (ignoreErrorsForDirectories [ "src/Api/Paack/Graphql", "src/Schemas", "src/I18n", "../src" ])


### PR DESCRIPTION
Though it's not ideal, this will unlock https://github.com/PaackEng/paack-ui/pull/195 for merging!

In the future, we can use the `--ignore-dirs` flag.
Or even drop this generic review.