### PR TITLE
Ignore frontend-elm-kit unused modules 

### DIFF
--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -23,7 +23,7 @@ import NoUnused.Modules
 import NoUnused.Parameters
 import NoUnused.Patterns
 import NoUnused.Variables
-import Review.Rule exposing (Rule)
+import Review.Rule exposing (Rule, ignoreErrorsForDirectories)
 
 
 {-| List of rules used with elm-review

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -40,6 +40,13 @@ config =
     , NoUnused.Patterns.rule
     , NoUnused.Variables.rule
     , NoUnused.CustomTypeConstructors.rule []
-    , NoUnused.Modules.rule
+    , ignoreErrorsForDirectories
+        [ frontendKitDirectory ]
+        NoUnused.Modules.rule
     , NoRedundantConcat.rule
     ]
+
+
+frontendKitDirectory : String
+frontendKitDirectory =
+    "frontend-elm-kit"


### PR DESCRIPTION
We need this as not every project will use every module from it.