### PR TITLE
Update and add new rules

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,10 +8,11 @@
         "direct": {
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
-            "jfmengels/elm-review": "2.3.8",
-            "jfmengels/elm-review-common": "1.0.3",
-            "jfmengels/elm-review-debug": "1.0.4",
-            "jfmengels/elm-review-unused": "1.1.4",
+            "jfmengels/elm-review": "2.7.1",
+            "jfmengels/elm-review-common": "1.2.0",
+            "jfmengels/elm-review-debug": "1.0.6",
+            "jfmengels/elm-review-simplify": "2.0.10",
+            "jfmengels/elm-review-unused": "1.1.21",
             "truqu/elm-review-nobooleancase": "1.0.0",
             "truqu/elm-review-noredundantconcat": "1.0.0",
             "truqu/elm-review-noredundantcons": "1.0.0"
@@ -19,17 +20,15 @@
         "indirect": {
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
-            "elm/project-metadata-utils": "1.0.1",
+            "elm/project-metadata-utils": "1.0.2",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "elm-community/json-extra": "4.3.0",
-            "elm-community/list-extra": "8.2.4",
+            "elm-community/list-extra": "8.5.2",
             "elm-explorations/test": "1.2.2",
+            "miniBill/elm-unicode": "1.0.2",
             "rtfeldman/elm-hex": "1.0.0",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
-            "stil4m/elm-syntax": "7.1.3",
+            "stil4m/elm-syntax": "7.2.9",
             "stil4m/structured-writer": "1.0.3"
         }
     },

--- a/elm.json
+++ b/elm.json
@@ -8,6 +8,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
+            "folq/review-rgb-ranges": "1.0.5",
             "jfmengels/elm-review": "2.7.1",
             "jfmengels/elm-review-common": "1.2.0",
             "jfmengels/elm-review-debug": "1.0.6",

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -17,6 +17,7 @@ import NoMissingTypeAnnotation
 import NoRedundantConcat
 import NoRedundantCons
 import NoUnused.CustomTypeConstructors
+import NoUnused.CustomTypeConstructorsArgs
 import NoUnused.Dependencies
 import NoUnused.Exports
 import NoUnused.Modules
@@ -38,7 +39,9 @@ config =
     , NoRedundantConcat.rule
     , NoRedundantCons.rule
     , NoUnused.CustomTypeConstructors.rule []
+    , NoUnused.CustomTypeConstructorsArgs.rule []
     , NoUnused.Dependencies.rule
+    , NoUnused.Exports.rule
     , NoUnused.Parameters.rule
     , NoUnused.Patterns.rule
     , NoUnused.Variables.rule

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -12,8 +12,11 @@ module ReviewConfig exposing (config)
 import NoBooleanCase
 import NoDebug.Log
 import NoDebug.TodoOrToString
+import NoDeprecated
 import NoExposingEverything
+import NoInvalidRGBValues
 import NoMissingTypeAnnotation
+import NoPrematureLetComputation
 import NoRedundantConcat
 import NoRedundantCons
 import NoUnused.CustomTypeConstructors
@@ -35,7 +38,10 @@ config =
     [ NoBooleanCase.rule
     , NoDebug.Log.rule
     , NoDebug.TodoOrToString.rule
+    , NoDeprecated.rule NoDeprecated.defaults
+    , NoInvalidRGBValues.rule
     , NoMissingTypeAnnotation.rule
+    , NoPrematureLetComputation.rule
     , NoRedundantConcat.rule
     , NoRedundantCons.rule
     , NoUnused.CustomTypeConstructors.rule []

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -45,7 +45,7 @@ config =
     , NoRedundantConcat.rule
     , NoRedundantCons.rule
     , NoUnused.CustomTypeConstructors.rule []
-    , NoUnused.CustomTypeConstructorArgs.rule []
+    , NoUnused.CustomTypeConstructorArgs.rule
     , NoUnused.Dependencies.rule
     , NoUnused.Exports.rule
     , NoUnused.Parameters.rule

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -24,26 +24,28 @@ import NoUnused.Parameters
 import NoUnused.Patterns
 import NoUnused.Variables
 import Review.Rule exposing (Rule, ignoreErrorsForDirectories)
+import Simplify
 
 
 {-| List of rules used with elm-review
 -}
 config : List Rule
 config =
-    [ NoDebug.Log.rule
+    [ NoBooleanCase.rule
+    , NoDebug.Log.rule
     , NoDebug.TodoOrToString.rule
-    , NoBooleanCase.rule
-    , NoRedundantCons.rule
     , NoMissingTypeAnnotation.rule
+    , NoRedundantConcat.rule
+    , NoRedundantCons.rule
+    , NoUnused.CustomTypeConstructors.rule []
     , NoUnused.Dependencies.rule
     , NoUnused.Parameters.rule
     , NoUnused.Patterns.rule
     , NoUnused.Variables.rule
-    , NoUnused.CustomTypeConstructors.rule []
+    , Simplify.rule Simplify.defaults
     , ignoreErrorsForDirectories
         [ frontendKitDirectory ]
         NoUnused.Modules.rule
-    , NoRedundantConcat.rule
     ]
 
 

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -19,8 +19,8 @@ import NoMissingTypeAnnotation
 import NoPrematureLetComputation
 import NoRedundantConcat
 import NoRedundantCons
+import NoUnused.CustomTypeConstructorArgs
 import NoUnused.CustomTypeConstructors
-import NoUnused.CustomTypeConstructorsArgs
 import NoUnused.Dependencies
 import NoUnused.Exports
 import NoUnused.Modules
@@ -45,7 +45,7 @@ config =
     , NoRedundantConcat.rule
     , NoRedundantCons.rule
     , NoUnused.CustomTypeConstructors.rule []
-    , NoUnused.CustomTypeConstructorsArgs.rule []
+    , NoUnused.CustomTypeConstructorArgs.rule []
     , NoUnused.Dependencies.rule
     , NoUnused.Exports.rule
     , NoUnused.Parameters.rule

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -19,7 +19,6 @@ import NoMissingTypeAnnotation
 import NoPrematureLetComputation
 import NoRedundantConcat
 import NoRedundantCons
-import NoUnused.CustomTypeConstructorArgs
 import NoUnused.CustomTypeConstructors
 import NoUnused.Dependencies
 import NoUnused.Exports
@@ -45,7 +44,6 @@ config =
     , NoRedundantConcat.rule
     , NoRedundantCons.rule
     , NoUnused.CustomTypeConstructors.rule []
-    , NoUnused.CustomTypeConstructorArgs.rule
     , NoUnused.Dependencies.rule
     , NoUnused.Exports.rule
     , NoUnused.Parameters.rule


### PR DESCRIPTION
# What?

- Update previous rules (Though elm-review does not consider package versioning);
- Disallow using modules/functions with `@deprecated` in its documentation or `DEPRECATED` in its name;
- Move `let..in`'s variables that do heavy calculations to where they're used (🏎);
- Disallow > 255 and negatives values in elm-ui's `rgb255`;
- Disallow > 1 and negatives values in elm-ui's `rgb`;
- Add all Simplify's rules (🏎);
- ~Disallow unused custom type constructors arguments~ (This proved useful for message types);
- Disallow unused exports.

# Why?

- To enhance our codebase quality.